### PR TITLE
Fix for tables containing text columns

### DIFF
--- a/lib/geo/postgis/extension.ex
+++ b/lib/geo/postgis/extension.ex
@@ -17,13 +17,13 @@ defmodule Geo.PostGIS.Extension do
 
       geo = %Geo.Point{coordinates: {30, -90}, srid: 4326}
       %Geo.Point{coordinates: {30, -90}, srid: 4326}
-      
+
       {:ok, _} = Postgrex.Connection.query(pid, "CREATE TABLE point_test (id int, geom geometry(Point, 4326))")
       {:ok, %Postgrex.Result{columns: nil, command: :create_table, num_rows: 0, rows: nil}}
-      
+
       {:ok, _} = Postgrex.Connection.query(pid, "INSERT INTO point_test VALUES ($1, $2)", [42, geo])
       {:ok, %Postgrex.Result{columns: nil, command: :insert, num_rows: 1, rows: nil}}
-      
+
       Postgrex.Connection.query(pid, "SELECT * FROM point_test")
       {:ok, %Postgrex.Result{columns: ["id", "geom"], command: :select, num_rows: 1,
       rows: [{42, %Geo.Point{coordinates: {30.0, -90.0}, srid: 4326}}]}}
@@ -33,23 +33,19 @@ defmodule Geo.PostGIS.Extension do
     :ok
   end
 
-  def matching(_) do 
-    [type: "geometry", send: "textsend"]
+  def matching(_) do
+    [type: "geometry"]
   end
 
   def format(_) do
     :text
   end
 
-  def encode(%TypeInfo{send: "textsend"}, geom, _state, _library) do 
+  def encode(%TypeInfo{type: "geometry"}, geom, _state, _library) do
     Geo.WKT.encode(geom)
   end
 
-  def encode(%TypeInfo{type: "geometry"}, geom, _state, _library) do 
-    Geo.WKT.encode(geom)
-  end
-
-  def decode(%TypeInfo{type: "geometry"}, wkb, _state, _library) do 
+  def decode(%TypeInfo{type: "geometry"}, wkb, _state, _library) do
     Geo.WKB.decode(wkb)
   end
 end

--- a/test/geo/postgis_test.exs
+++ b/test/geo/postgis_test.exs
@@ -2,7 +2,7 @@ defmodule Geo.PostGIS.Test do
   use ExUnit.Case, async: true
 
   setup do
-    opts = [hostname: "localhost", 
+    opts = [hostname: "localhost",
     username: "postgres", database: "geo_postgrex_test",
     extensions: [{Geo.PostGIS.Extension, library: Geo}]]
 
@@ -18,6 +18,15 @@ defmodule Geo.PostGIS.Test do
     {:ok, _} = Postgrex.Connection.query(pid, "INSERT INTO point_test VALUES ($1, $2)", [42, geo])
     {:ok, result} = Postgrex.Connection.query(pid, "SELECT * FROM point_test", [])
     assert(result.rows == [{42, geo}])
+  end
+
+  test "insert with text column", context do
+    pid = context[:pid]
+    geo = %Geo.Point{ coordinates: {30, -90}, srid: 4326}
+    {:ok, _} = Postgrex.Connection.query(pid, "CREATE TABLE text_test (id int, t text, geom geometry(Point, 4326))", [])
+    {:ok, _} = Postgrex.Connection.query(pid, "INSERT INTO text_test (id, t, geom) VALUES ($1, $2, $3)", [42, "test", geo])
+    {:ok, result} = Postgrex.Connection.query(pid, "SELECT id, t, geom FROM text_test", [])
+    assert(result.rows == [{42, "test", geo}])
   end
 
   test "insert linestring", context do


### PR DESCRIPTION
I see errors when a table contains text columns, it looks like the extension is trying to parse the wrong columns.

This works for me... Not sure if it has other implications though.