### PR TITLE
Correct Postgrex extension name in Ecto documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ end
     password: "postgres",
     hostname: "localhost",
     adapter: Ecto.Adapters.Postgres,
-    extensions: [{Geo.PostGIS, library: Geo}]
+    extensions: [{Geo.PostGIS.Extension, library: Geo}]
 
 
   #Create a model


### PR DESCRIPTION
It didn't work when I used the existing documentation for the Ecto usage. When changing it to this it worked, as this is the correct name of the Postgrex Extension.