### PR TITLE
Added an opts parameter to Geo.JSON.encode to allow for skipping json encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.15.2
+* Enhancements
+  * Added an `opts` parameter to `Geo.JSON.encode` to allow for skipping JSON encoding
+
 # v0.15.1
 * Enhancements
   * Fixed st_dwithin macro

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ end
 
   iex(2)> Geo.JSON.encode(point)
   "{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}"
+
+  iex(3)> Geo.JSON.encode(point, [skip_json: true])
+  %{ type: "Point", coordinates: [100.0, 0.0] }
   ```
 
 * A Postgrex Extension for the PostGIS data types, Geometry and Geography

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -46,11 +46,14 @@ A collection of GIS functions. Handles conversions to and from WKT, WKB, and Geo
 * Encode and decode GeoJSON
 
   ```elixir
-  iex(1)> point = Geo.JSON.decode("{ \"type\": \"Point\", \"coordinates\": [100.0, 0.0] }")
+  iex(1)> point = Geo.JSON.decode("{ \\"type\\": \\"Point\\", \\"coordinates\\": [100.0, 0.0] }")
   %Geo.Point{ coordinates: {100.0, 0.0}, srid: nil }
 
   iex(2)> Geo.JSON.encode(point)
-  "{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}"
+  "{\\"type\\":\\"Point\\",\\"coordinates\\":[100.0,0.0]}"
+
+  iex(2)> Geo.JSON.encode(point, [skip_json: true])
+  %{ type: "Point", coordinates: [100.0, 0.0] }
   ```
 
 * Postgrex Extension for PostGIS data types, Geometry and Geography

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Geo.Mixfile do
 
   def project do
     [ app: :geo,
-      version: "0.15.1",
+      version: "0.15.2",
       elixir: "~> 1.0.0",
       deps: deps,
       description: description,

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -1,6 +1,13 @@
 defmodule Geo.JSON.Test do
   use ExUnit.Case, async: true
 
+  test "Point to GeoJson Map" do
+    geom = %Geo.Point{ coordinates: {100.0, 0.0} }
+    json = Geo.JSON.encode(geom, [skip_json: true])
+
+    assert json == %{ type: "Point", coordinates: [100.0, 0.0] }
+  end
+
   test "Point to GeoJson" do
     geom = %Geo.Point{ coordinates: {100.0, 0.0} }
     json = Geo.JSON.encode(geom)


### PR DESCRIPTION
See #24. This adds an opts parameter to skip json encoding when needed.

```elixir
  iex(3)> Geo.JSON.encode(point, [skip_json: true])
  %{ type: "Point", coordinates: [100.0, 0.0] }
```