### PR TITLE
Allow running Geo against Ecto 2.0-beta release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Geo.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 1.1", optional: true },
+      {:ecto, "~> 1.1 or ~> 2.0-beta", optional: true },
       {:postgrex, "~> 0.11", optional: true },
       {:poison, "~> 1.5 or ~> 2.0", optional: true},
       {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,13 +2,13 @@
   "db_connection": {:hex, :db_connection, "0.2.3"},
   "decimal": {:hex, :decimal, "1.1.1"},
   "earmark": {:hex, :earmark, "0.2.1"},
-  "ecto": {:hex, :ecto, "1.1.3"},
+  "ecto": {:hex, :ecto, "2.0.0-beta.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "hex": {:git, "git://github.com/rjsamson/hex.git", "48e3e0887153baa0a34879ebf649ae0af15ef386", []},
   "jazz": {:hex, :jazz, "0.2.1"},
   "jsex": {:git, "git://github.com/talentdeficit/jsex.git", "91fbbb51ac18c5ecec45044af107cd079af2ff8b", []},
   "json": {:git, "git://github.com/cblage/elixir-json.git", "f386b18431bbc0a0b6d38519ec2f256b5a040668", []},
   "jsx": {:hex, :jsx, "2.1.1"},
-  "poison": {:hex, :poison, "1.5.2"},
+  "poison": {:hex, :poison, "2.1.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.11.0"}}
+  "postgrex": {:hex, :postgrex, "0.11.1"}}

--- a/test/geo/ecto_test.exs
+++ b/test/geo/ecto_test.exs
@@ -11,7 +11,7 @@ defmodule Geo.Ecto.Test do
   end
 
   defmodule Location do
-    use Ecto.Model
+    use Ecto.Schema
 
     schema "locations" do
       field :name,           :string
@@ -20,7 +20,7 @@ defmodule Geo.Ecto.Test do
   end
 
   defmodule Geographies do
-    use Ecto.Model
+    use Ecto.Schema
 
     schema "geographies" do
       field :name,           :string


### PR DESCRIPTION
There are warnings running the tests due to Repo.one being deprecated
but replacing the calls with Repo.first would preclude running against
Ecto 1.1.x.