### PR TITLE
Add handling of spaces between comma and open-parens on WKT.

### DIFF
--- a/lib/geo/wkt.ex
+++ b/lib/geo/wkt.ex
@@ -147,7 +147,7 @@ defmodule Geo.WKT do
     coordinates
     |> String.strip
     |> remove_outer_parenthesis
-    |> String.split(~r{\), ?\(})
+    |> String.split(~r{\), *\(})
     |> Enum.map(&repair_str(&1, "(", ")"))
     |> Enum.map(&create_line_string(&1))
   end
@@ -156,7 +156,7 @@ defmodule Geo.WKT do
     coordinates
     |> String.strip
     |> remove_outer_parenthesis
-    |> String.split(~r{\)\), ?\(\(})
+    |> String.split(~r{\)\), *\(\(})
     |> Enum.map(&repair_str(&1, "((", "))"))
     |> Enum.map(&create_polygon(&1))
   end

--- a/lib/geo/wkt.ex
+++ b/lib/geo/wkt.ex
@@ -147,7 +147,7 @@ defmodule Geo.WKT do
     coordinates
     |> String.strip
     |> remove_outer_parenthesis
-    |> String.split("),(")
+    |> String.split(~r{\), ?\(})
     |> Enum.map(&repair_str(&1, "(", ")"))
     |> Enum.map(&create_line_string(&1))
   end
@@ -156,7 +156,7 @@ defmodule Geo.WKT do
     coordinates
     |> String.strip
     |> remove_outer_parenthesis
-    |> String.split(")),((")
+    |> String.split(~r{\)\), ?\(\(})
     |> Enum.map(&repair_str(&1, "((", "))"))
     |> Enum.map(&create_polygon(&1))
   end

--- a/test/geo/wkt_test.exs
+++ b/test/geo/wkt_test.exs
@@ -47,6 +47,11 @@ defmodule Geo.WKT.Test do
     assert(geom.coordinates == [ [{35, 10}, {45, 45}, {15, 40}, {10, 20}, {35, 10}], [{20, 30}, {35, 35}, {30, 20}, {20, 30}] ])
   end
 
+  test "Decode WKT with spaces between exterior and holes to Polygon 2" do
+    geom = Geo.WKT.decode("POLYGON((35 10,45 45,15 40,10 20,35 10), (20 30,35 35,30 20,20 30))")
+    assert(geom.coordinates == [ [{35, 10}, {45, 45}, {15, 40}, {10, 20}, {35, 10}], [{20, 30}, {35, 35}, {30, 20}, {20, 30}] ])
+  end
+
   test "Encode MultiPoint to WKT" do
     geom = %Geo.MultiPoint{ coordinates: [{0, 0}, {20, 20}, {60, 60}] }
     assert(Geo.WKT.encode(geom) == "MULTIPOINT(0 0,20 20,60 60)")
@@ -73,6 +78,11 @@ defmodule Geo.WKT.Test do
     assert(geom.coordinates == [[{10, 10}, {20, 20}, {10, 40}], [{40, 40}, {30, 30}, {40, 20}, {30, 10}]])
   end
 
+  test "Decode WKT with spaces between LineStrings to MultiLineString" do
+    geom = Geo.WKT.decode("MULTILINESTRING((10 10,20 20,10 40), (40 40,30 30,40 20,30 10))")
+    assert(geom.coordinates == [[{10, 10}, {20, 20}, {10, 40}], [{40, 40}, {30, 30}, {40, 20}, {30, 10}]])
+  end
+
   test "Decode EWKT to MultiLineString" do
     geom = Geo.WKT.decode("SRID=4326;MULTILINESTRING((10 10,20 20,10 40),(40 40,30 30,40 20,30 10))")
     assert(geom.coordinates == [[{10, 10}, {20, 20}, {10, 40}], [{40, 40}, {30, 30}, {40, 20}, {30, 10}]])
@@ -86,6 +96,11 @@ defmodule Geo.WKT.Test do
 
   test "Decode WKT to MultiPolygon" do
     geom = Geo.WKT.decode("MULTIPOLYGON(((40 40,20 45,45 30,40 40)),((20 35,10 30,10 10,30 5,45 20,20 35),(30 20,20 15,20 25,30 20)))")
+    assert(geom.coordinates == [ [ [{40, 40}, {20, 45}, {45, 30}, {40, 40}] ], [ [{20, 35}, {10, 30}, {10, 10}, {30, 5}, {45, 20}, {20, 35}], [{30, 20}, {20, 15}, {20, 25}, {30, 20}] ] ] )
+  end
+
+  test "Decode WKT with spaces between polygons to MultiPolygon" do
+    geom = Geo.WKT.decode("MULTIPOLYGON(((40 40,20 45,45 30,40 40)), ((20 35,10 30,10 10,30 5,45 20,20 35), (30 20,20 15,20 25,30 20)))")
     assert(geom.coordinates == [ [ [{40, 40}, {20, 45}, {45, 30}, {40, 40}] ], [ [{20, 35}, {10, 30}, {10, 10}, {30, 5}, {45, 20}, {20, 35}], [{30, 20}, {20, 15}, {20, 25}, {30, 20}] ] ] )
   end
 


### PR DESCRIPTION
Valid WKT strings such as "POLYGON((35 10,45 45,15 40,10 20,35 10), (20 30,35 35,30 20,20 30))" where a space is added between the comma and the open-parens of the hole are being decoded to a single list of points.

```
iex(1)> Geo.WKT.decode("POLYGON((35 10,45 45,15 40,10 20,35 10),(20 30,35 35,30 20,20 30))")
%Geo.Polygon{coordinates: [[{35, 10}, {45, 45}, {15, 40}, {10, 20}, {35, 10}],
  [{20, 30}, {35, 35}, {30, 20}, {20, 30}]], srid: nil}
iex(2)> Geo.WKT.decode("POLYGON((35 10,45 45,15 40,10 20,35 10), (20 30,35 35,30 20,20 30))")
%Geo.Polygon{coordinates: [[{35, 10}, {45, 45}, {15, 40}, {10, 20}, {35, 10},
   {20, 30}, {35, 35}, {30, 20}, {20, 30}]], srid: nil}
```

This PR addresses this by using a Regex in the split instead of a static `"),("` string.