### PR TITLE
Remove release candidate and allow for 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Geo.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 1.1 or ~> 2.0-rc", optional: true },
+      {:ecto, "~> 1.1 or ~> 2.0", optional: true },
       {:postgrex, "~> 0.11.1", optional: true },
       {:poison, "~> 1.5 or ~> 2.0", optional: true},
       {:earmark, "~> 0.2", only: :dev},


### PR DESCRIPTION
## What does this PR do?

Thanks for geo I use it in production with an API for a client. 

And since yesterday Ecto 2.0 was released I want to be able to use `geo` and `ecto` with 2.0 that's why I changed the dependency from `2.0-rc` to `2.0`

