### PR TITLE
Avoid call to deprecated ST_Distance_Sphere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: elixir
 elixir:
@@ -6,7 +7,7 @@ otp_release:
   - 18.0
   - 19.0
 addons:
-  postgresql: "9.6"
+  postgresql: '9.6'
 services:
   - postgresql
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
   - 18.0
   - 19.0
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 services:
   - postgresql
 before_script:

--- a/lib/geo/postgis.ex
+++ b/lib/geo/postgis.ex
@@ -28,7 +28,7 @@ if Code.ensure_loaded?(Ecto.Query) do
     end
 
     defmacro st_distance_sphere(geometryA, geometryB) do
-      quote do: fragment("ST_Distance_Sphere(?,?)", unquote(geometryA), unquote(geometryB))
+      quote do: fragment("ST_DistanceSphere(?,?)", unquote(geometryA), unquote(geometryB))
     end
 
     defmacro st_dwithin(geometryA, geometryB, float) do

--- a/lib/geo/postgis.ex
+++ b/lib/geo/postgis.ex
@@ -28,7 +28,7 @@ if Code.ensure_loaded?(Ecto.Query) do
     end
 
     defmacro st_distance_sphere(geometryA, geometryB) do
-      quote do: fragment("ST_DistanceSphere(?,?)", unquote(geometryA), unquote(geometryB))
+      quote do: fragment("ST_Distance_Sphere(?,?)", unquote(geometryA), unquote(geometryB))
     end
 
     defmacro st_dwithin(geometryA, geometryB, float) do

--- a/lib/geo/postgis.ex
+++ b/lib/geo/postgis.ex
@@ -27,6 +27,15 @@ if Code.ensure_loaded?(Ecto.Query) do
       quote do: fragment("ST_Distance(?,?)", unquote(geometryA), unquote(geometryB))
     end
 
+    defmacro st_distancesphere(geometryA, geometryB) do
+      quote do: fragment("ST_DistanceSphere(?,?)", unquote(geometryA), unquote(geometryB))
+    end
+
+    @doc"""
+    Please note that ST_Distance_Sphere has been deprecated as of Postgis 2.2.
+    Postgis 2.1 is no longer supported on PostgreSQL >= 9.5.
+    This macro is still in place to support users of PostgreSQL <= 9.4.x.
+    """
     defmacro st_distance_sphere(geometryA, geometryB) do
       quote do: fragment("ST_Distance_Sphere(?,?)", unquote(geometryA), unquote(geometryB))
     end

--- a/test/geo/ecto_test.exs
+++ b/test/geo/ecto_test.exs
@@ -98,7 +98,7 @@ defmodule Geo.Ecto.Test do
 
     Repo.insert(%Location{name: "hello", geom: geom})
 
-    query = from location in Location, limit: 5, select: st_distance_sphere(location.geom, ^geom)
+    query = from location in Location, limit: 5, select: st_distancesphere(location.geom, ^geom)
     results = Repo.one(query)
 
     assert results == 0


### PR DESCRIPTION
Switch to using ST_DistanceSphere instead. This avoids frequent warnings
in the postgresql server log.