### PR TITLE
fixing String.strip() deprecations in Elixir 1.5

### DIFF
--- a/lib/geo/wkt.ex
+++ b/lib/geo/wkt.ex
@@ -154,7 +154,7 @@ defmodule Geo.WKT do
 
   defp create_point(coordinates) do
     coordinates
-    |> String.strip
+    |> String.trim
     |> remove_outer_parenthesis
     |> String.split
     |> Enum.map(fn(x) -> binary_to_number(x) end)
@@ -163,7 +163,7 @@ defmodule Geo.WKT do
 
   defp create_line_string(coordinates) do
     coordinates
-    |> String.strip
+    |> String.trim
     |> remove_outer_parenthesis
     |> String.split(",")
     |> Enum.map(&create_point(&1))
@@ -171,7 +171,7 @@ defmodule Geo.WKT do
 
   defp create_polygon(coordinates) do
     coordinates
-    |> String.strip
+    |> String.trim
     |> remove_outer_parenthesis
     |> String.split(~r{\), *\(})
     |> Enum.map(&repair_str(&1, "(", ")"))
@@ -180,7 +180,7 @@ defmodule Geo.WKT do
 
   defp create_multi_polygon(coordinates) do
     coordinates
-    |> String.strip
+    |> String.trim
     |> remove_outer_parenthesis
     |> String.split(~r{\)\), *\(\(})
     |> Enum.map(&repair_str(&1, "((", "))"))


### PR DESCRIPTION
Hi, 
  I replaced all the strip function calls with trim, since strip was deprecated in Elixir 1.5.

Cheers,

Sebastian A. Espindola