### PR TITLE
Change handling of EPSG/SRID to match standard

### DIFF
--- a/lib/geo/geo_json.ex
+++ b/lib/geo/geo_json.ex
@@ -109,6 +109,14 @@ defmodule Geo.JSON do
     srid
   end
 
+  # Previous versions of this library incorrectly encoded the name without the
+  # colon. This clause allows JSON encoded with those versions to still be
+  # decoded.
+  defp get_srid(%{"type" => "name", "properties" => %{ "name" => "EPSG" <> srid } }) do
+    {srid, _} = Integer.parse(srid)
+    srid
+  end
+
   defp get_srid(%{"type" => "name", "properties" => %{ "name" => srid } }) do
     srid
   end

--- a/lib/geo/geo_json.ex
+++ b/lib/geo/geo_json.ex
@@ -104,7 +104,7 @@ defmodule Geo.JSON do
     %MultiPolygon{ coordinates: coordinates, srid: get_srid(crs) }
   end
 
-  defp get_srid(%{"type" => "name", "properties" => %{ "name" => "EPSG" <> srid } }) do
+  defp get_srid(%{"type" => "name", "properties" => %{ "name" => "EPSG:" <> srid } }) do
     {srid, _} = Integer.parse(srid)
     srid
   end
@@ -185,7 +185,7 @@ defmodule Geo.JSON do
   end
 
   defp add_crs(map, srid) do
-    Map.put(map, "crs", %{"type" => "name", "properties" => %{"name" => "EPSG#{srid}"}})
+    Map.put(map, "crs", %{"type" => "name", "properties" => %{"name" => "EPSG:#{srid}"}})
   end
 
 end

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -33,6 +33,18 @@ defmodule Geo.JSON.Test do
     assert(exjson == new_exjson)
   end
 
+  test "GeoJson with SRID to Point and back" do
+    json = "{\"type\":\"Point\",\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}},\"coordinates\":[100.0, 101.0]}"
+    exjson = Poison.decode!(json)
+    geom = Poison.decode!(json) |> Geo.JSON.decode
+
+    assert(geom.coordinates == {100.0, 101.0})
+    assert(geom.srid == 4326)
+
+    new_exjson = Geo.JSON.encode(geom)
+    assert(exjson == new_exjson)
+  end
+
   test "GeoJson to LineString and back" do
     json = "{ \"type\": \"LineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ]}"
     exjson = Poison.decode!(json)


### PR DESCRIPTION
PostGIS' `ST_AsGeoJSON()` function (http://www.postgis.net/docs/ST_AsGeoJSON.html) produces a CRS field with a colon between `EPSG` and the SRID integer, eg `EPSG:4326`. Googling around, this appears to be the standard way of doing things. The existing code expects no colon (`EPSG4326`). I've changed it to match what seems to be the standard.

The catch with this change is that anyone who's encoded a geom with the old code will not be able to decode with the new version. If you think that's likely to be an issue, it could be resolved by adding back in the old clause for `get_srid/1` between the new version and the version that takes `nil`. I didn't do that in order to keep the code simple, but I have no problem with doing so.