### PR TITLE
Improve Geo.JSON encoding and decoding

### DIFF
--- a/lib/geo/json.ex
+++ b/lib/geo/json.ex
@@ -1,29 +1,5 @@
 defmodule Geo.JSON do
-  alias Geo.Point
-  alias Geo.LineString
-  alias Geo.Polygon
-  alias Geo.MultiPoint
-  alias Geo.MultiLineString
-  alias Geo.MultiPolygon
-  alias Geo.GeometryCollection
-
-  alias Geo.JSON.{
-    Decoder
-  }
-
-  defmodule EncodeError do
-    @type t :: %EncodeError{message: String.t, value: any}
-
-    defexception [:message, :value]
-
-    def message(%{message: nil, value: value}) do
-      "unable to encode value: #{inspect(value)}"
-    end
-
-    def message(%{message: message}) do
-      message
-    end
-  end
+  alias Geo.JSON.{Decoder, Encoder}
 
   @moduledoc """
   Converts Geo structs to and from a map representing GeoJSON.
@@ -41,10 +17,10 @@ defmodule Geo.JSON do
   geom = Poison.decode!(json) |> Geo.JSON.decode!(json)
   Geo.Point[coordinates: {100.0, 0.0}, srid: nil]
 
-  Geo.JSON.encode(geom) |> Poison.encode!
+  Geo.JSON.encode!(geom) |> Poison.encode!
   "{ \\"type\\": \\"Point\\", \\"coordinates\\": [100.0, 0.0] }"
 
-  Geo.JSON.encode(geom)
+  Geo.JSON.encode!(geom)
   %{ "type" => "Point", "coordinates" => [100.0, 0.0] }
   ```
   """
@@ -64,73 +40,12 @@ defmodule Geo.JSON do
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
-  @spec encode(Geo.geometry()) :: Map.t()
-  def encode(geom) do
-    case geom do
-      %GeometryCollection{geometries: geometries, srid: srid} ->
-        %{"type" => "GeometryCollection", "geometries" => Enum.map(geometries, &do_encode(&1))}
-        |> add_crs(srid)
+  @spec encode!(Geo.geometry()) :: Map.t() | no_return
+  defdelegate encode!(geom), to: Encoder
 
-      _ ->
-        do_encode(geom)
-        |> add_crs(geom.srid)
-    end
-  end
-
-  defp do_encode(%Point{coordinates: {x, y}}) do
-    %{"type" => "Point", "coordinates" => [x, y]}
-  end
-
-  defp do_encode(%LineString{coordinates: coordinates}) do
-    coordinates = Enum.map(coordinates, &Tuple.to_list(&1))
-
-    %{"type" => "LineString", "coordinates" => coordinates}
-  end
-
-  defp do_encode(%Polygon{coordinates: coordinates}) do
-    coordinates =
-      Enum.map(coordinates, fn sub_coordinates ->
-        Enum.map(sub_coordinates, &Tuple.to_list(&1))
-      end)
-
-    %{"type" => "Polygon", "coordinates" => coordinates}
-  end
-
-  defp do_encode(%MultiPoint{coordinates: coordinates}) do
-    coordinates = Enum.map(coordinates, &Tuple.to_list(&1))
-
-    %{"type" => "MultiPoint", "coordinates" => coordinates}
-  end
-
-  defp do_encode(%MultiLineString{coordinates: coordinates}) do
-    coordinates =
-      Enum.map(coordinates, fn sub_coordinates ->
-        Enum.map(sub_coordinates, &Tuple.to_list(&1))
-      end)
-
-    %{"type" => "MultiLineString", "coordinates" => coordinates}
-  end
-
-  defp do_encode(%MultiPolygon{coordinates: coordinates}) do
-    coordinates =
-      Enum.map(coordinates, fn sub_coordinates ->
-        Enum.map(sub_coordinates, fn third_sub_coordinates ->
-          Enum.map(third_sub_coordinates, &Tuple.to_list(&1))
-        end)
-      end)
-
-    %{"type" => "MultiPolygon", "coordinates" => coordinates}
-  end
-
-  defp do_encode(data) do
-    raise EncodeError, message: "Unable to encode given value: #{inspect(data)}"
-  end
-
-  defp add_crs(map, nil) do
-    map
-  end
-
-  defp add_crs(map, srid) do
-    Map.put(map, "crs", %{"type" => "name", "properties" => %{"name" => "EPSG:#{srid}"}})
-  end
+  @doc """
+  Takes a Geometry and returns a map representing the GeoJSON
+  """
+  @spec encode(Geo.geometry()) :: {:ok, Map.t()} | {:error, Encoder.EncodeError.t()}
+  defdelegate encode(geom), to: Encoder
 end

--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -14,7 +14,7 @@ defmodule Geo.JSON.Decoder do
 
     defexception [:message, :value]
 
-      def message(%{message: nil, value: value}) do
+    def message(%{message: nil, value: value}) do
       "unable to decode value: #{inspect(value)}"
     end
 

--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -105,7 +105,7 @@ defmodule Geo.JSON.Decoder do
   end
 
   defp do_decode(type, _, _) do
-    raise DecodeError, message: "#{type} is not a valid"
+    raise DecodeError, message: "#{type} is not a valid type"
   end
 
   defp get_srid(%{"type" => "name", "properties" => %{"name" => "EPSG:" <> srid}}) do

--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -1,0 +1,131 @@
+defmodule Geo.JSON.Decoder do
+  alias Geo.{
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection
+  }
+
+  defmodule DecodeError do
+    @type t :: %__MODULE__{message: String.t, value: any}
+
+    defexception [:message, :value]
+
+      def message(%{message: nil, value: value}) do
+      "unable to decode value: #{inspect(value)}"
+    end
+
+    def message(%{message: message}) do
+      message
+    end
+  end
+
+  @doc """
+  Takes a map representing GeoJSON and returns a Geometry
+  """
+  @spec decode!(Map.t()) :: Geo.geometry() | no_return
+  def decode!(geo_json) do
+    cond do
+      Map.has_key?(geo_json, "geometries") ->
+        crs = Map.get(geo_json, "crs")
+
+        geometries =
+          Enum.map(Map.get(geo_json, "geometries"), fn x ->
+            do_decode(Map.get(x, "type"), Map.get(x, "coordinates"), crs)
+          end)
+
+        %GeometryCollection{geometries: geometries}
+
+      Map.has_key?(geo_json, "coordinates") ->
+        crs = Map.get(geo_json, "crs")
+        do_decode(Map.get(geo_json, "type"), Map.get(geo_json, "coordinates"), crs)
+
+      true ->
+        raise DecodeError, value: geo_json
+    end
+  end
+
+  @doc """
+  Takes a map representing GeoJSON and returns a Geometry
+  """
+  @spec decode(Map.t()) :: {:ok, Geo.geometry()} | {:error, DecodeError.t()}
+  def decode(geo_json) do
+    {:ok, decode!(geo_json)}
+  rescue
+    exception in [DecodeError] ->
+      {:error, exception}
+  end
+
+  defp do_decode("Point", [x, y], crs) do
+    %Point{coordinates: {x, y}, srid: get_srid(crs)}
+  end
+
+  defp do_decode("LineString", coordinates, crs) do
+    coordinates = Enum.map(coordinates, &List.to_tuple(&1))
+
+    %LineString{coordinates: coordinates, srid: get_srid(crs)}
+  end
+
+  defp do_decode("Polygon", coordinates, crs) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, &List.to_tuple(&1))
+      end)
+
+    %Polygon{coordinates: coordinates, srid: get_srid(crs)}
+  end
+
+  defp do_decode("MultiPoint", coordinates, crs) do
+    coordinates = Enum.map(coordinates, &List.to_tuple(&1))
+
+    %MultiPoint{coordinates: coordinates, srid: get_srid(crs)}
+  end
+
+  defp do_decode("MultiLineString", coordinates, crs) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, &List.to_tuple(&1))
+      end)
+
+    %MultiLineString{coordinates: coordinates, srid: get_srid(crs)}
+  end
+
+  defp do_decode("MultiPolygon", coordinates, crs) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, fn third_sub_coordinates ->
+          Enum.map(third_sub_coordinates, &List.to_tuple(&1))
+        end)
+      end)
+
+    %MultiPolygon{coordinates: coordinates, srid: get_srid(crs)}
+  end
+
+  defp do_decode(type, _, _) do
+    raise DecodeError, message: "#{type} is not a valid"
+  end
+
+  defp get_srid(%{"type" => "name", "properties" => %{"name" => "EPSG:" <> srid}}) do
+    {srid, _} = Integer.parse(srid)
+    srid
+  end
+
+  # Previous versions of this library incorrectly encoded the name without the
+  # colon. This clause allows JSON encoded with those versions to still be
+  # decoded.
+  defp get_srid(%{"type" => "name", "properties" => %{"name" => "EPSG" <> srid}}) do
+    {srid, _} = Integer.parse(srid)
+    srid
+  end
+
+  defp get_srid(%{"type" => "name", "properties" => %{"name" => srid}}) do
+    srid
+  end
+
+  defp get_srid(nil) do
+    nil
+  end
+end

--- a/lib/geo/json/encoder.ex
+++ b/lib/geo/json/encoder.ex
@@ -1,0 +1,109 @@
+defmodule Geo.JSON.Encoder do
+  alias Geo.{
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection
+  }
+
+  defmodule EncodeError do
+    @type t :: %__MODULE__{message: String.t, value: any}
+
+    defexception [:message, :value]
+
+    def message(%{message: nil, value: value}) do
+      "unable to encode value: #{inspect(value)}"
+    end
+
+    def message(%{message: message}) do
+      message
+    end
+  end
+
+  @doc """
+  Takes a Geometry and returns a map representing the GeoJSON
+  """
+  @spec encode!(Geo.geometry()) :: Map.t()
+  def encode!(geom) do
+    case geom do
+      %GeometryCollection{geometries: geometries, srid: srid} ->
+        %{"type" => "GeometryCollection", "geometries" => Enum.map(geometries, &do_encode(&1))}
+        |> add_crs(srid)
+
+      _ ->
+        do_encode(geom)
+        |> add_crs(geom.srid)
+    end
+  end
+
+  @doc """
+  Takes a Geometry and returns a map representing the GeoJSON
+  """
+  @spec encode(Geo.geometry()) :: {:ok, Map.t()} | {:error, EncodeError.t()}
+  def encode(geom) do
+    {:ok, encode!(geom)}
+  rescue
+    exception in [EncodeError] ->
+      {:error, exception}
+  end
+
+  defp do_encode(%Point{coordinates: {x, y}}) do
+    %{"type" => "Point", "coordinates" => [x, y]}
+  end
+
+  defp do_encode(%LineString{coordinates: coordinates}) do
+    coordinates = Enum.map(coordinates, &Tuple.to_list(&1))
+
+    %{"type" => "LineString", "coordinates" => coordinates}
+  end
+
+  defp do_encode(%Polygon{coordinates: coordinates}) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, &Tuple.to_list(&1))
+      end)
+
+    %{"type" => "Polygon", "coordinates" => coordinates}
+  end
+
+  defp do_encode(%MultiPoint{coordinates: coordinates}) do
+    coordinates = Enum.map(coordinates, &Tuple.to_list(&1))
+
+    %{"type" => "MultiPoint", "coordinates" => coordinates}
+  end
+
+  defp do_encode(%MultiLineString{coordinates: coordinates}) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, &Tuple.to_list(&1))
+      end)
+
+    %{"type" => "MultiLineString", "coordinates" => coordinates}
+  end
+
+  defp do_encode(%MultiPolygon{coordinates: coordinates}) do
+    coordinates =
+      Enum.map(coordinates, fn sub_coordinates ->
+        Enum.map(sub_coordinates, fn third_sub_coordinates ->
+          Enum.map(third_sub_coordinates, &Tuple.to_list(&1))
+        end)
+      end)
+
+    %{"type" => "MultiPolygon", "coordinates" => coordinates}
+  end
+
+  defp do_encode(data) do
+    raise EncodeError, message: "Unable to encode given value: #{inspect(data)}"
+  end
+
+  defp add_crs(map, nil) do
+    map
+  end
+
+  defp add_crs(map, srid) do
+    Map.put(map, "crs", %{"type" => "name", "properties" => %{"name" => "EPSG:#{srid}"}})
+  end
+end

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -3,21 +3,21 @@ defmodule Geo.JSON.Test do
 
   test "Point to GeoJson Map" do
     geom = %Geo.Point{coordinates: {100.0, 0.0}}
-    json = Geo.JSON.encode(geom)
+    json = Geo.JSON.encode!(geom)
 
     assert json == %{"type" => "Point", "coordinates" => [100.0, 0.0]}
   end
 
   test "Point to GeoJson" do
     geom = %Geo.Point{coordinates: {100.0, 0.0}}
-    json = Geo.JSON.encode(geom) |> Poison.encode!()
+    json = Geo.JSON.encode!(geom) |> Poison.encode!()
 
     assert(json == "{\"type\":\"Point\",\"coordinates\":[100.0,0.0]}")
   end
 
   test "LineString to GeoJson" do
     geom = %Geo.LineString{coordinates: [{100.0, 0.0}, {101.0, 1.0}]}
-    json = Geo.JSON.encode(geom) |> Poison.encode!()
+    json = Geo.JSON.encode!(geom) |> Poison.encode!()
 
     assert(json == "{\"type\":\"LineString\",\"coordinates\":[[100.0,0.0],[101.0,1.0]]}")
   end
@@ -29,7 +29,7 @@ defmodule Geo.JSON.Test do
 
     assert(geom.coordinates == {100.0, 0.0})
 
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -43,7 +43,7 @@ defmodule Geo.JSON.Test do
     assert(geom.coordinates == {100.0, 101.0})
     assert(geom.srid == 4326)
 
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -53,7 +53,7 @@ defmodule Geo.JSON.Test do
     geom = Poison.decode!(json) |> Geo.JSON.decode!()
 
     assert(geom.coordinates == [{100.0, 0.0}, {101.0, 1.0}])
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -68,7 +68,7 @@ defmodule Geo.JSON.Test do
       geom.coordinates == [[{100.0, 0.0}, {101.0, 0.0}, {101.0, 1.0}, {100.0, 1.0}, {100.0, 0.0}]]
     )
 
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -78,7 +78,7 @@ defmodule Geo.JSON.Test do
     geom = Poison.decode!(json) |> Geo.JSON.decode!()
 
     assert(geom.coordinates == [{100.0, 0.0}, {101.0, 1.0}])
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -90,7 +90,7 @@ defmodule Geo.JSON.Test do
     geom = Poison.decode!(json) |> Geo.JSON.decode!()
 
     assert(geom.coordinates == [[{100.0, 0.0}, {101.0, 1.0}], [{102.0, 2.0}, {103.0, 3.0}]])
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -111,7 +111,7 @@ defmodule Geo.JSON.Test do
       ]
     )
 
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
@@ -124,13 +124,13 @@ defmodule Geo.JSON.Test do
 
     assert(Enum.count(geom.geometries) == 2)
 
-    new_exjson = Geo.JSON.encode(geom)
+    new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
   end
 
   test "Unable to encode non-geo type" do
-    assert_raise Geo.JSON.EncodeError, fn ->
-      Geo.JSON.encode(%{a: "b"})
+    assert_raise Geo.JSON.Encoder.EncodeError, fn ->
+      Geo.JSON.encode!(%{a: "b"})
     end
   end
 
@@ -170,5 +170,13 @@ defmodule Geo.JSON.Test do
 
     assert {:ok, _value} = Poison.decode!(valid_json) |> Geo.JSON.decode()
     assert {:error, _error} = Poison.decode!(invalid_json) |> Geo.JSON.decode()
+  end
+
+  test "encode/1" do
+    valid_geom = %Geo.LineString{coordinates: [{100.0, 0.0}, {101.0, 1.0}]}
+    invalid_geom = %{random: 123}
+
+    assert {:ok, _map} = Geo.JSON.encode(valid_geom)
+    assert {:error, _error} = Geo.JSON.encode(invalid_geom)
   end
 end


### PR DESCRIPTION
- Fix an issue when you pass a random type to the decoding process
- Create Encoder and Decoder modules following Poison code style, I think this improve the readability

## Breaking changes

`Geo.JSON.encode` becomes `Geo.JSON.encode!`
`Geo.JSON.decode` becomes `Geo.JSON.decode!`

Because normally `!` from code style on Elixir people would expect a error to be rise if something goes wrong.