### PR TITLE
Support WKB empty multipolygons

### DIFF
--- a/lib/geo/wkb/decoder.ex
+++ b/lib/geo/wkb/decoder.ex
@@ -157,7 +157,11 @@ defmodule Geo.WKB.Decoder do
   defp decode_coordinates(_geom, wkb_reader) do
     {_number_of_items, wkb_reader} = Reader.read(wkb_reader, 8)
 
-    decoded_geom = wkb_reader.wkb |> decode!()
+    decoded_geom =
+      case wkb_reader.wkb do
+        "" -> []
+        wkb -> decode!(wkb)
+      end
 
     coordinates =
       if is_list(decoded_geom) do

--- a/test/geo/wkb_test.exs
+++ b/test/geo/wkb_test.exs
@@ -254,6 +254,12 @@ defmodule Geo.WKB.Test do
     assert(point.srid == 4326)
   end
 
+  test "Decode empty MultiPolygon EWKB to MultiPolygon" do
+    multipolygon = Geo.WKB.decode!("0106000020E610000000000000")
+    assert(multipolygon.coordinates == [])
+    assert(multipolygon.srid == 4326)
+  end
+
   test "Encode MultiPolygon to WKB" do
     geom = %Geo.MultiPolygon{
       coordinates: [


### PR DESCRIPTION
Currently `Geo.WKB.decode/2` throws an exception when decoding
an empty multipolygon:

```
Geo.WKB.decode!("0106000020E610000000000000")
** (MatchError) no match of right hand side value: ""
    (geo) lib/geo/wkb/reader.ex:6: Geo.WKB.Reader.new/1
    (geo) lib/geo/wkb/decoder.ex:35: Geo.WKB.Decoder.decode!/2
    (geo) lib/geo/wkb/decoder.ex:160: Geo.WKB.Decoder.decode_coordinates/2
    (geo) lib/geo/wkb/decoder.ex:50: Geo.WKB.Decoder.decode!/2
```

This PR fixes it.