### PR TITLE
Optimise reverse_byte_order/1

### DIFF
--- a/lib/geo/utils.ex
+++ b/lib/geo/utils.ex
@@ -68,11 +68,15 @@ defmodule Geo.Utils do
   end
 
   def reverse_byte_order(hex) do
-    byte_range = Enum.to_list(0..(div(byte_size(hex), 2) - 1))
+    do_reverse_byte_order(hex, "")
+  end
 
-    Enum.map(byte_range, fn x -> :binary.part(hex, x * 2, 2) end)
-    |> Enum.reverse()
-    |> Enum.join()
+  defp do_reverse_byte_order("", acc) do
+    acc
+  end
+
+  defp do_reverse_byte_order(<<a, b, rest :: binary>>, acc) do
+    do_reverse_byte_order(rest, <<a, b, acc :: binary>>)
   end
 
   @doc """


### PR DESCRIPTION
The `reverse_byte_order/1` function was not especially quick. In an Ecto postgres query with a large number of geo fields, it ended up taking a significant percentage of the total time. I have some `fprof` files if you're interested in details, but the short version is that this change reduced the time to process the geo fields on 2000 objects (running under `fprof`, so the times are larger than they would otherwise be) from 1358ms to 142ms for the same query (the first value represented 42% of the total query time).