### PR TITLE
Correctly encode and decode all valid geojson

### DIFF
--- a/lib/geo/json/encoder.ex
+++ b/lib/geo/json/encoder.ex
@@ -60,7 +60,7 @@ defmodule Geo.JSON.Encoder do
   end
 
   defp do_encode(%PointZ{coordinates: {x, y, z}}) do
-    %{"type" => "PointZ", "coordinates" => [x, y, z]}
+    %{"type" => "Point", "coordinates" => [x, y, z]}
   end
 
   defp do_encode(%LineString{coordinates: coordinates}) do

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -19,14 +19,21 @@ defmodule Geo.JSON.Test do
     geom = %Geo.PointZ{coordinates: {100.0, 0.0, 70.0}}
     json = Geo.JSON.encode!(geom)
 
-    assert json == %{"type" => "PointZ", "coordinates" => [100.0, 0.0, 70.0]}
+    assert json == %{"type" => "Point", "coordinates" => [100.0, 0.0, 70.0]}
   end
 
   test "PointZ to GeoJson" do
     geom = %Geo.PointZ{coordinates: {100.0, 0.0, 70.0}}
     json = Geo.JSON.encode!(geom) |> Poison.encode!()
 
-    assert(json == "{\"type\":\"PointZ\",\"coordinates\":[100.0,0.0,70.0]}")
+    assert(json == "{\"type\":\"Point\",\"coordinates\":[100.0,0.0,70.0]}")
+  end
+
+  test "PointZ from GeoJson" do
+    json = "{\"type\":\"Point\",\"coordinates\":[100.0,0.0,70.0]}"
+    geom = Poison.decode!(json) |> Geo.JSON.decode!()
+
+    assert(geom == %Geo.PointZ{coordinates: {100.0, 0.0, 70.0}})
   end
 
   test "LineString to GeoJson" do
@@ -69,6 +76,18 @@ defmodule Geo.JSON.Test do
     assert(geom.coordinates == [{100.0, 0.0}, {101.0, 1.0}])
     new_exjson = Geo.JSON.encode!(geom)
     assert(exjson == new_exjson)
+  end
+
+  test "Throw altitude away from things other than points" do
+    json =
+      "{ \"type\": \"Polygon\", \"coordinates\": [[ [100.0, 0.0, 1.0], [101.0, 0.0, 1.0], [101.0, 1.0, 1.0], [100.0, 1.0, 1.0], [100.0, 0.0, 1.0] ]]}"
+
+    geom = Poison.decode!(json) |> Geo.JSON.decode!()
+
+    assert(
+      geom.coordinates == [[{100.0, 0.0}, {101.0, 0.0}, {101.0, 1.0}, {100.0, 1.0}, {100.0, 0.0}]]
+    )
+
   end
 
   test "GeoJson to Polygon and back" do


### PR DESCRIPTION
This will finish the support for decoding all valid geojson files that follow the rfc. If there is data that `Geo` does not support that extra data is simply thrown away.
Also allows us to encode PointZ in accordance with the GeoJSON rfc.

Encoder:

 * `%Point{}`  ➡️  `{"type": "Point", "coordinates": [1,2]}`
 * `%PointZ{}` ➡️ `{"type": "Point", "coordinates": [1,2, 3]}`

Decoder:

 * `{"type": "Point", "coordinates": [1,2]}` ➡️ `%Point{}`
 * `{"type": "Point", "coordinates": [1,2,3]}` ➡️  `%PointZ{}`
 * `{"type": "OtherGeometriesWith3Elements", "coordinates": [1,2,3]}` ➡️  __discard the 3rd element__

The encoding part still gives error on `%PointM{}` and `%PointZM{}`. If we want to we can simply translate those the the closest thing as such:

 * `%PointZM{}` -> `{"type": "Point", "coordinates": [1,2, 3]}`
 * `%PointM{}` -> `{"type": "Point", "coordinates": [1,2]}`

Although we _could_ support PointZM with a four element array. I don't think there is anything in the RFC that strictly forbids it although it's discouraged.