### PR TITLE
Allow to disable String.Chars implementation for Geo objects

### DIFF
--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -77,21 +77,23 @@ defmodule Geo do
 
   @type endian :: :ndr | :xdr
 
-  defimpl String.Chars,
-    for: [
-      Geo.Point,
-      Geo.PointZ,
-      Geo.PointM,
-      Geo.PointZM,
-      Geo.LineString,
-      Geo.Polygon,
-      Geo.MultiPoint,
-      Geo.MultiLineString,
-      Geo.MultiPolygon,
-      Geo.GeometryCollection
-    ] do
-    def to_string(geo) do
-      Geo.WKT.encode!(geo)
+  if Application.get_env(:geo, :impl_to_string, true) do
+    defimpl String.Chars,
+      for: [
+        Geo.Point,
+        Geo.PointZ,
+        Geo.PointM,
+        Geo.PointZM,
+        Geo.LineString,
+        Geo.Polygon,
+        Geo.MultiPoint,
+        Geo.MultiLineString,
+        Geo.MultiPolygon,
+        Geo.GeometryCollection
+      ] do
+      def to_string(geo) do
+        Geo.WKT.encode!(geo)
+      end
     end
   end
 end


### PR DESCRIPTION
Hello,

I'm using geo_postgis for a web application in which I store GPS coordinates and I would like to change the default string representation of a `Geo.Point`, as WKT is not well-known enough for end-user.

This small change would allow me to disable the default String.Chars implementation by simply adding the following config:

```elixir
config :geo, impl_to_string: false
```

The default behavior of the project is not changed at all.