### PR TITLE
Tweaking type specs

### DIFF
--- a/lib/geo/geometry_collection.ex
+++ b/lib/geo/geometry_collection.ex
@@ -3,6 +3,6 @@ defmodule Geo.GeometryCollection do
   Defines the GeometryCollection struct.
   """
 
-  @type t :: %Geo.GeometryCollection{geometries: [Geo.geometry()], srid: integer, properties: map}
+  @type t :: %Geo.GeometryCollection{geometries: [Geo.geometry()], srid: integer | nil, properties: map}
   defstruct geometries: [], srid: nil, properties: %{}
 end

--- a/lib/geo/json.ex
+++ b/lib/geo/json.ex
@@ -28,24 +28,24 @@ defmodule Geo.JSON do
   @doc """
   Takes a map representing GeoJSON and returns a Geometry
   """
-  @spec decode!(Map.t()) :: Geo.geometry() | no_return
+  @spec decode!(map()) :: Geo.geometry() | no_return
   defdelegate decode!(geo_json), to: Decoder
 
   @doc """
   Takes a map representing GeoJSON and returns a Geometry
   """
-  @spec decode(Map.t()) :: {:ok, Geo.geometry()} | {:error, Decoder.DecodeError.t()}
+  @spec decode(map()) :: {:ok, Geo.geometry()} | {:error, Decoder.DecodeError.t()}
   defdelegate decode(geo_json), to: Decoder
 
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
-  @spec encode!(Geo.geometry()) :: Map.t() | no_return
+  @spec encode!(Geo.geometry()) :: map() | no_return
   defdelegate encode!(geom), to: Encoder
 
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
-  @spec encode(Geo.geometry()) :: {:ok, Map.t()} | {:error, Encoder.EncodeError.t()}
+  @spec encode(Geo.geometry()) :: {:ok, map()} | {:error, Encoder.EncodeError.t()}
   defdelegate encode(geom), to: Encoder
 end

--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -30,7 +30,7 @@ defmodule Geo.JSON.Decoder do
   @doc """
   Takes a map representing GeoJSON and returns a Geometry
   """
-  @spec decode!(Map.t()) :: Geo.geometry() | no_return
+  @spec decode!(map()) :: Geo.geometry() | no_return
   def decode!(geo_json) do
     cond do
       Map.has_key?(geo_json, "geometries") ->
@@ -93,7 +93,7 @@ defmodule Geo.JSON.Decoder do
   @doc """
   Takes a map representing GeoJSON and returns a Geometry
   """
-  @spec decode(Map.t()) :: {:ok, Geo.geometry()} | {:error, DecodeError.t()}
+  @spec decode(map()) :: {:ok, Geo.geometry()} | {:error, DecodeError.t()}
   def decode(geo_json) do
     {:ok, decode!(geo_json)}
   rescue

--- a/lib/geo/json/encoder.ex
+++ b/lib/geo/json/encoder.ex
@@ -34,7 +34,7 @@ defmodule Geo.JSON.Encoder do
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
-  @spec encode!(Geo.geometry()) :: Map.t()
+  @spec encode!(Geo.geometry()) :: map()
   def encode!(geom) do
     case geom do
       %GeometryCollection{geometries: geometries, srid: srid, properties: properties} ->
@@ -52,7 +52,7 @@ defmodule Geo.JSON.Encoder do
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
-  @spec encode(Geo.geometry()) :: {:ok, Map.t()} | {:error, EncodeError.t()}
+  @spec encode(Geo.geometry()) :: {:ok, map()} | {:error, EncodeError.t()}
   def encode(geom) do
     {:ok, encode!(geom)}
   rescue

--- a/lib/geo/line_string.ex
+++ b/lib/geo/line_string.ex
@@ -3,6 +3,6 @@ defmodule Geo.LineString do
   Defines the LineString struct.
   """
 
-  @type t :: %Geo.LineString{coordinates: [{number, number}], srid: integer, properties: map}
+  @type t :: %Geo.LineString{coordinates: [{number, number}], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/line_stringz.ex
+++ b/lib/geo/line_stringz.ex
@@ -3,6 +3,6 @@ defmodule Geo.LineStringZ do
   Defines the LineStringZ struct.
   """
 
-  @type t :: %__MODULE__{coordinates: [{number, number, number}], srid: integer, properties: map}
+  @type t :: %__MODULE__{coordinates: [{number, number, number}], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/multi_line_string.ex
+++ b/lib/geo/multi_line_string.ex
@@ -5,7 +5,7 @@ defmodule Geo.MultiLineString do
 
   @type t :: %Geo.MultiLineString{
           coordinates: [[{number, number}]],
-          srid: integer,
+          srid: integer | nil,
           properties: map
         }
   defstruct coordinates: [], srid: nil, properties: %{}

--- a/lib/geo/multi_line_stringz.ex
+++ b/lib/geo/multi_line_stringz.ex
@@ -5,7 +5,7 @@ defmodule Geo.MultiLineStringZ do
 
   @type t :: %__MODULE__{
           coordinates: [[{number, number, number}]],
-          srid: integer,
+          srid: integer | nil,
           properties: map
         }
   defstruct coordinates: [], srid: nil, properties: %{}

--- a/lib/geo/multi_point.ex
+++ b/lib/geo/multi_point.ex
@@ -3,6 +3,6 @@ defmodule Geo.MultiPoint do
   Defines the MultiPoint struct.
   """
 
-  @type t :: %Geo.MultiPoint{coordinates: [{number, number}], srid: integer, properties: map}
+  @type t :: %Geo.MultiPoint{coordinates: [{number, number}], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/multi_pointz.ex
+++ b/lib/geo/multi_pointz.ex
@@ -3,6 +3,6 @@ defmodule Geo.MultiPointZ do
   Defines the MultiPointZ struct.
   """
 
-  @type t :: %__MODULE__{coordinates: [{number, number, number}], srid: integer, properties: map}
+  @type t :: %__MODULE__{coordinates: [{number, number, number}], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/multi_polygon.ex
+++ b/lib/geo/multi_polygon.ex
@@ -5,7 +5,7 @@ defmodule Geo.MultiPolygon do
 
   @type t :: %Geo.MultiPolygon{
           coordinates: [[[{number, number}]]],
-          srid: integer,
+          srid: integer | nil,
           properties: map
         }
   defstruct coordinates: [], srid: nil, properties: %{}

--- a/lib/geo/multi_polygonz.ex
+++ b/lib/geo/multi_polygonz.ex
@@ -5,7 +5,7 @@ defmodule Geo.MultiPolygonZ do
 
   @type t :: %__MODULE__{
           coordinates: [[[{number, number, number}]]],
-          srid: integer,
+          srid: integer | nil,
           properties: map
         }
   defstruct coordinates: [], srid: nil, properties: %{}

--- a/lib/geo/point.ex
+++ b/lib/geo/point.ex
@@ -3,6 +3,6 @@ defmodule Geo.Point do
   Defines the Point struct.
   """
 
-  @type t :: %Geo.Point{coordinates: {number, number}, srid: integer, properties: map}
+  @type t :: %Geo.Point{coordinates: {number, number}, srid: integer | nil, properties: map}
   defstruct coordinates: {0, 0}, srid: nil, properties: %{}
 end

--- a/lib/geo/pointm.ex
+++ b/lib/geo/pointm.ex
@@ -3,6 +3,6 @@ defmodule Geo.PointM do
   Defines the PointM struct.
   """
 
-  @type t :: %Geo.PointM{coordinates: {number, number, number}, srid: integer, properties: map}
+  @type t :: %Geo.PointM{coordinates: {number, number, number}, srid: integer | nil, properties: map}
   defstruct coordinates: {0, 0, 0}, srid: nil, properties: %{}
 end

--- a/lib/geo/pointz.ex
+++ b/lib/geo/pointz.ex
@@ -3,6 +3,6 @@ defmodule Geo.PointZ do
   Defines the PointZ struct.
   """
 
-  @type t :: %Geo.PointZ{coordinates: {number, number, number}, srid: integer, properties: map}
+  @type t :: %Geo.PointZ{coordinates: {number, number, number}, srid: integer | nil, properties: map}
   defstruct coordinates: {0, 0, 0}, srid: nil, properties: %{}
 end

--- a/lib/geo/pointzm.ex
+++ b/lib/geo/pointzm.ex
@@ -5,7 +5,7 @@ defmodule Geo.PointZM do
 
   @type t :: %Geo.PointZM{
           coordinates: {number, number, number, number},
-          srid: integer,
+          srid: integer | nil,
           properties: map
         }
   defstruct coordinates: {0, 0, 0, 0}, srid: nil, properties: %{}

--- a/lib/geo/polygon.ex
+++ b/lib/geo/polygon.ex
@@ -3,6 +3,6 @@ defmodule Geo.Polygon do
   Defines the Polygon struct.
   """
 
-  @type t :: %Geo.Polygon{coordinates: [[{number, number}]], srid: integer, properties: map}
+  @type t :: %Geo.Polygon{coordinates: [[{number, number}]], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/polygonz.ex
+++ b/lib/geo/polygonz.ex
@@ -3,6 +3,6 @@ defmodule Geo.PolygonZ do
   Defines the Polygon struct.
   """
 
-  @type t :: %__MODULE__{coordinates: [[{number, number, number}]], srid: integer, properties: map}
+  @type t :: %__MODULE__{coordinates: [[{number, number, number}]], srid: integer | nil, properties: map}
   defstruct coordinates: [], srid: nil, properties: %{}
 end

--- a/lib/geo/wkb.ex
+++ b/lib/geo/wkb.ex
@@ -18,7 +18,7 @@ defmodule Geo.WKB do
   Takes a Geometry and returns a WKB string. The endian decides
   what the byte order will be
   """
-  @spec encode!(binary, Geo.endian()) :: binary | no_return
+  @spec encode!(Geo.geometry(), Geo.endian()) :: binary | no_return
   defdelegate encode!(geom, endian \\ :xdr), to: Encoder
 
   @doc """

--- a/lib/geo/wkb/encoder.ex
+++ b/lib/geo/wkb/encoder.ex
@@ -40,7 +40,7 @@ defmodule Geo.WKB.Encoder do
   Takes a Geometry and returns a WKB string. The endian decides
   what the byte order will be
   """
-  @spec encode!(binary, Geo.endian()) :: binary | no_return
+  @spec encode!(Geo.geometry(), Geo.endian()) :: binary | no_return
   def encode!(geom, endian \\ :xdr) do
     writer = Writer.new(endian)
     do_encode(geom, writer)

--- a/lib/geo/wkt.ex
+++ b/lib/geo/wkt.ex
@@ -24,7 +24,7 @@ defmodule Geo.WKT do
   @doc """
   Takes a Geometry and returns a WKT string
   """
-  @spec encode(Geo.geometry()) :: binary
+  @spec encode!(Geo.geometry()) :: binary
   defdelegate encode!(geom), to: Encoder
 
   @doc """

--- a/lib/geo/wkt/encoder.ex
+++ b/lib/geo/wkt/encoder.ex
@@ -22,7 +22,7 @@ defmodule Geo.WKT.Encoder do
   @doc """
   Takes a Geometry and returns a WKT string
   """
-  @spec encode(binary) :: {:ok, binary} | {:error, Exception.t()}
+  @spec encode(Geo.geometry()) :: {:ok, binary} | {:error, Exception.t()}
   def encode(geom) do
     {:ok, encode!(geom)}
   rescue


### PR DESCRIPTION
I pulled `geo` into a library of mine and had some dialyzer issues. I ran dialyzer against `geo` and uncovered a few incorrect specs. This PR addresses them.

- `Map.t()` isn't a valid type. Changed it to `map()`.
- The `Geo.WKT.encode!/1` spec had a typo (missing the `!`)
- All the structs that make up the `Geo.geometry()` type could return `nil` under the `srid` key. Technically, you'd only need to change one of the struct specs, but it felt like the right thing to change them all.
- A few different `WKT` and `WKB` functions related to encoding were spec'd to accept `binary` as their first argument. Should be `Geo.geometry()` instead.