### PR TITLE
add GeoJSON Feature and FeatureCollection encoding

### DIFF
--- a/lib/geo/json.ex
+++ b/lib/geo/json.ex
@@ -42,10 +42,12 @@ defmodule Geo.JSON do
   """
   @spec encode!(Geo.geometry()) :: map() | no_return
   defdelegate encode!(geom), to: Encoder
+  defdelegate encode!(geom, opts), to: Encoder
 
   @doc """
   Takes a Geometry and returns a map representing the GeoJSON
   """
   @spec encode(Geo.geometry()) :: {:ok, map()} | {:error, Encoder.EncodeError.t()}
   defdelegate encode(geom), to: Encoder
+  defdelegate encode(geom, opts), to: Encoder
 end

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -303,4 +303,66 @@ defmodule Geo.JSON.Test do
       assert geom == Geo.JSON.encode!(geom) |> Geo.JSON.decode!()
     end
   end
+
+  test "Point with properties to GeoJSON Feature map" do
+    geom = %Geo.Point{coordinates: {100.0, 0.0}, properties: %{hi: "there"}}
+
+    expected = %{
+      "type" => "Feature",
+      "properties" => %{
+        "hi" => "there"
+      },
+      "geometry" => %{
+        "type" => "Point",
+        "coordinates" => [
+          100.0,
+          0.0
+        ]
+      }
+    }
+
+    assert(Geo.JSON.encode!(geom, feature: true) == expected)
+  end
+
+  test "Collection with properties to GeoJSON FeatureCollection map" do
+    p1 = %Geo.Point{coordinates: {100.0, 0.0}, properties: %{hi: "there"}}
+    p2 = %Geo.Point{coordinates: {0.0, 45.0}, properties: %{foo: 456.78}}
+    gc = %Geo.GeometryCollection{geometries: [p1, p2], properties: %{hi: "other", foo: 123.45}}
+
+    expected = %{
+      "type" => "FeatureCollection",
+      "features" => [
+        %{
+          "type" => "Feature",
+          "properties" => %{
+            "hi" => "there",
+            "foo" => 123.45
+          },
+          "geometry" => %{
+            "type" => "Point",
+            "coordinates" => [
+              100.0,
+              0.0
+            ]
+          }
+        },
+        %{
+          "type" => "Feature",
+          "properties" => %{
+            "hi" => "other",
+            "foo" => 456.78
+          },
+          "geometry" => %{
+            "type" => "Point",
+            "coordinates" => [
+              0.0,
+              45.0
+            ]
+          }
+        }
+      ]
+    }
+
+    assert(Geo.JSON.encode!(gc, feature: true) == expected)
+  end
 end


### PR DESCRIPTION
* Geo.JSON.encode!/1 behaves exactly the same
* Geo.JSON.encode!/2 accepts `feature: true` to use new behavior

see #119 

agree with @achedeuzot, thanks for the great lib. here is an attempt to address encoding to GeoJSON Feature/FeatureCollection types without breaking existing structure.