### PR TITLE
Update typespec to make Point easier to use.

### DIFF
--- a/lib/geo/point.ex
+++ b/lib/geo/point.ex
@@ -3,6 +3,9 @@ defmodule Geo.Point do
   Defines the Point struct.
   """
 
-  @type t :: %Geo.Point{coordinates: {number, number}, srid: integer | nil, properties: map}
+  @type latitude :: atom
+  @type longitude :: atom
+
+  @type t :: %Geo.Point{coordinates: {longitude, latitude}, srid: integer | nil, properties: map}
   defstruct coordinates: {0, 0}, srid: nil, properties: %{}
 end


### PR DESCRIPTION
Hi there! I know this wasn't asked for, so my feelings won't be hurt if it doesn't make it in, but we use this under the hood at Community and it felt like a small way to say thanks.

I watched a coworker make an identical mistake to one I made about a year ago and it seemed like this might help. People who aren't used to post gis, or GIS in general, will typically refer back to when they learned about coordinates and at least in my upbringing, latitude is always mentioned first, the opposite of what is needed here.

When I went through this last year, slightly more detailed type spec would have saved me a few days of cleanup after a botched migration.

If you would like me to do this in more places or if there is anything else you would like to see from this, please just let me know.

Thanks for you work.