### PR TITLE
Add JSON decoding support for LineStringZ

### DIFF
--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -5,6 +5,7 @@ defmodule Geo.JSON.Decoder do
     Point,
     PointZ,
     LineString,
+    LineStringZ,
     Polygon,
     MultiPoint,
     MultiLineString,
@@ -113,6 +114,12 @@ defmodule Geo.JSON.Decoder do
     coordinates = Enum.map(coordinates, &list_to_tuple(&1))
 
     %LineString{coordinates: coordinates, srid: get_srid(crs), properties: properties}
+  end
+
+  defp do_decode("LineStringZ", coordinates, properties, crs) do
+    coordinates = Enum.map(coordinates, &List.to_tuple(&1))
+
+    %LineStringZ{coordinates: coordinates, srid: get_srid(crs), properties: properties}
   end
 
   defp do_decode("Polygon", coordinates, properties, crs) do

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -79,6 +79,16 @@ defmodule Geo.JSON.Test do
     assert(exjson == new_exjson)
   end
 
+  test "GeoJson to LineStringZ and back" do
+    json = "{ \"type\": \"LineStringZ\", \"coordinates\": [ [100.0, 0.0, 50.0], [101.0, 1.0, 20.0] ]}"
+    exjson = Poison.decode!(json)
+    geom = Poison.decode!(json) |> Geo.JSON.decode!()
+
+    assert(geom.coordinates == [{100.0, 0.0, 50.0}, {101.0, 1.0, 20.0}])
+    new_exjson = Geo.JSON.encode!(geom)
+    assert(exjson == new_exjson)
+  end
+
   test "Throw altitude away from things other than points" do
     json =
       "{ \"type\": \"Polygon\", \"coordinates\": [[ [100.0, 0.0, 1.0], [101.0, 0.0, 1.0], [101.0, 1.0, 1.0], [100.0, 1.0, 1.0], [100.0, 0.0, 1.0] ]]}"


### PR DESCRIPTION
This PR adds support for decoding a `LineStringZ` from a GeoJSON.