### PR TITLE
Make Jason optional

### DIFF
--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -119,26 +119,28 @@ defmodule Geo do
     end
   end
 
-  defimpl Jason.Encoder,
-    for: [
-      Geo.Point,
-      Geo.PointZ,
-      Geo.PointM,
-      Geo.PointZM,
-      Geo.LineString,
-      Geo.LineStringZ,
-      Geo.Polygon,
-      Geo.PolygonZ,
-      Geo.MultiPoint,
-      Geo.MultiPointZ,
-      Geo.MultiLineString,
-      Geo.MultiLineStringZ,
-      Geo.MultiPolygon,
-      Geo.MultiPolygonZ,
-      Geo.GeometryCollection
-    ] do
-    def encode(value, opts) do
-      Jason.Encode.map(Geo.JSON.encode!(value), opts)
+  if Code.ensure_loaded?(Jason.Encoder) do
+    defimpl Jason.Encoder,
+      for: [
+        Geo.Point,
+        Geo.PointZ,
+        Geo.PointM,
+        Geo.PointZM,
+        Geo.LineString,
+        Geo.LineStringZ,
+        Geo.Polygon,
+        Geo.PolygonZ,
+        Geo.MultiPoint,
+        Geo.MultiPointZ,
+        Geo.MultiLineString,
+        Geo.MultiLineStringZ,
+        Geo.MultiPolygon,
+        Geo.MultiPolygonZ,
+        Geo.GeometryCollection
+      ] do
+      def encode(value, opts) do
+        Jason.Encode.map(Geo.JSON.encode!(value), opts)
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Geo.Mixfile do
 
   defp deps do
     [
-      {:jason, "~> 1.2", only: :test},
+      {:jason, "~> 1.2", optional: true},
       {:ex_doc, "~> 0.18", only: :dev},
       {:excoveralls, "~> 0.12.1", only: :test},
       {:stream_data, "~> 0.4.3", only: :test},


### PR DESCRIPTION
Hi!

As @wojtekmach mentioned, `Jason` support introduced earlier added a hard dependency on Jason, so the geo would fail to compile as a result.

I've made `jason` optional and guarded `Jason.Encoder` protocol implementation with an `if`.

Resolves https://github.com/bryanjos/geo/pull/141#discussion_r518342383_