### PR TITLE
Remove config/

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :logger, level: :warn


### PR DESCRIPTION
I'd assume the logger level was to silence out stuff in tests but that doesn't seem to be the case.
