### PR TITLE
Ignore extra elements in positions

### DIFF
--- a/lib/geo/json/decoder.ex
+++ b/lib/geo/json/decoder.ex
@@ -180,8 +180,7 @@ defmodule Geo.JSON.Decoder do
     raise DecodeError, message: "#{type} is not a valid type"
   end
 
-  defp list_to_tuple([x, y, _z]), do: {x, y}
-  defp list_to_tuple([x, y]), do: {x, y}
+  defp list_to_tuple([x, y | _]), do: {x, y}
 
   defp get_srid(%{"type" => "name", "properties" => %{"name" => "EPSG:" <> srid}}) do
     {srid, _} = Integer.parse(srid)

--- a/test/geo/json_test.exs
+++ b/test/geo/json_test.exs
@@ -91,9 +91,9 @@ defmodule Geo.JSON.Test do
     assert(exjson == new_exjson)
   end
 
-  test "Throw altitude away from things other than points" do
+  test "Throw altitude away and any extra elements from things other than points" do
     json =
-      "{ \"type\": \"Polygon\", \"coordinates\": [[ [100.0, 0.0, 1.0], [101.0, 0.0, 1.0], [101.0, 1.0, 1.0], [100.0, 1.0, 1.0], [100.0, 0.0, 1.0] ]]}"
+      "{ \"type\": \"Polygon\", \"coordinates\": [[ [100.0, 0.0, 1.0, null], [101.0, 0.0, 1.0, null], [101.0, 1.0, 1.0, null], [100.0, 1.0, 1.0, null], [100.0, 0.0, 1.0, null] ]]}"
 
     geom = Jason.decode!(json) |> Geo.JSON.decode!()
 


### PR DESCRIPTION
According to the GeoJSON spec:

> A position is an array of numbers.  There MUST be two or more
> elements.  The first two elements are longitude and latitude, or
> easting and northing, precisely in that order and using decimal
> numbers.  Altitude or elevation MAY be included as an optional third
> element.
>
> Implementations SHOULD NOT extend positions beyond three elements
> because the semantics of extra elements are unspecified and
> ambiguous.  Historically, some implementations have used a fourth
> element to carry a linear referencing measure (sometimes denoted as
> "M") or a numerical timestamp, but in most situations a parser will
> not be able to properly interpret these values.  **The interpretation
> and meaning of additional elements is beyond the scope of this
> specification, and additional elements MAY be ignored by parsers.**
https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1

We are already ignoring the altitude, but not handling the case when
there are additional elements provided.

This PR adds handling for those by explicitly ignoring them when decoding
a geojson.