### PR TITLE
Replace use Bitwise with Import Bitwise

### DIFF
--- a/lib/geo/utils.ex
+++ b/lib/geo/utils.ex
@@ -1,6 +1,6 @@
 defmodule Geo.Utils do
   @moduledoc false
-  use Bitwise
+  import Bitwise
 
   @doc """
   Turns a hex string or an integer of base 16 into its floating point

--- a/lib/geo/wkb/decoder.ex
+++ b/lib/geo/wkb/decoder.ex
@@ -19,7 +19,7 @@ defmodule Geo.WKB.Decoder do
 
   @wkbsridflag 0x20000000
 
-  use Bitwise
+  import Bitwise
 
   alias Geo.{
     Point,

--- a/lib/geo/wkb/encoder.ex
+++ b/lib/geo/wkb/encoder.ex
@@ -19,8 +19,6 @@ defmodule Geo.WKB.Encoder do
 
   @wkbsridflag 0x20000000
 
-  use Bitwise
-
   alias Geo.{
     Point,
     PointZ,


### PR DESCRIPTION
```elixir
use Bitwise
```

is deprecated in the future elixir version, so I replaced it with recommended

```elixir
import Bitwise
```
